### PR TITLE
Fix Sign-in and Sign-up pages

### DIFF
--- a/train-a/src/app/app.routes.ts
+++ b/train-a/src/app/app.routes.ts
@@ -51,5 +51,4 @@ export const routes: Routes = [
       // { path: 'routes', component: RoutesComponent }
     ],
   },
-  { path: '**', redirectTo: 'signup' },
 ];

--- a/train-a/src/app/auth/components/signin-form/signin-form.component.html
+++ b/train-a/src/app/auth/components/signin-form/signin-form.component.html
@@ -17,7 +17,7 @@
   </mat-form-field>
 
   <div class="buttons-container">
-    <button mat-flat-button [disabled]="!isValid" class="signin" (click)="onSubmit()">Sign In</button>
+    <button mat-flat-button [disabled]="!isValid || (isLoading$ | async)" class="signin" (click)="onSubmit()">Sign In</button>
     <button mat-button routerLink="/signup">Sign Up</button>
   </div>
 </form>

--- a/train-a/src/app/auth/components/signin-form/signin-form.component.ts
+++ b/train-a/src/app/auth/components/signin-form/signin-form.component.ts
@@ -20,6 +20,7 @@ export class SigninFormComponent implements OnInit {
   isSubmitted = false;
   authError$ = this.authFacade.authError$;
   authToken$ = this.authFacade.authToken$;
+  isLoading$ = this.authFacade.isLoading$;
 
   constructor(
     private fb: FormBuilder,

--- a/train-a/src/app/auth/components/signin-form/signin-form.component.ts
+++ b/train-a/src/app/auth/components/signin-form/signin-form.component.ts
@@ -53,7 +53,7 @@ export class SigninFormComponent implements OnInit {
       const control = this.signinForm.get(field);
       if (control?.hasError('serverError')) {
         control.setErrors({ serverError: null });
-        control.updateValueAndValidity({ onlySelf: true });
+        control.updateValueAndValidity({ emitEvent: false });
       }
     });
   }

--- a/train-a/src/app/auth/components/signup-form/signup-form.component.html
+++ b/train-a/src/app/auth/components/signup-form/signup-form.component.html
@@ -25,7 +25,7 @@
     </mat-error>
   </mat-form-field>
   <div class="buttons-container">
-    <button mat-flat-button [disabled]="!isValid" class="signup" (click)="onSubmit()">Register</button>
+    <button mat-flat-button [disabled]="!isValid || (isLoading$ | async)" class="signup" (click)="onSubmit()">Register</button>
     <button mat-button routerLink="/signin">Sign In</button>
   </div>
 </form>

--- a/train-a/src/app/auth/components/signup-form/signup-form.component.ts
+++ b/train-a/src/app/auth/components/signup-form/signup-form.component.ts
@@ -30,6 +30,7 @@ export class SignupFormComponent implements OnInit {
   isSubmitted = false;
   authError$ = this.authFacade.authError$;
   isRegistered$ = this.authFacade.isRegistered$;
+  isLoading$ = this.authFacade.isLoading$;
 
   matcher: ErrorStateMatcher = {
     isErrorState: (control: FormControl | null): boolean => !!(control && control.invalid && (control.dirty || control.touched)),

--- a/train-a/src/app/auth/state/auth.facade.ts
+++ b/train-a/src/app/auth/state/auth.facade.ts
@@ -10,6 +10,7 @@ import * as AuthSelectors from './auth.selectors';
 export class AuthFacade {
   isRegistered$ = this.store.select(AuthSelectors.selectIsRegistered);
   isLoggedIn$ = this.store.select(AuthSelectors.selectIsLoggedIn);
+  isLoading$ = this.store.select(AuthSelectors.selectIsLoading);
   authToken$ = this.store.select(AuthSelectors.selectAuthToken);
   authError$ = this.store.select(AuthSelectors.selectError);
 


### PR DESCRIPTION
### U.P. Create Sign-Up \ Sign-In Page

Rationale: 

- Changed synchronous error clearing. Previously, errors were cleared the second time.
- Added `disabled` to buttons if the user is signing in or signing up.